### PR TITLE
Adicionado pasta 'database' ao gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out/
 .idea/
 *.iml
 target/
+database/
 
 ### Eclipse ###
 .apt_generated


### PR DESCRIPTION
Essa pasta é criada quando o código é iniciado e ela é usada para armazenar o banco de dados.